### PR TITLE
Minute read English Translation Change

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -6,9 +6,7 @@
   translation: "Oops! Page Not Found..."
 
 - id: readingTime
-  translation:
-    one: "One minute read"
-    other: "{{ .Count }} minutes read"
+  translation: "{{ .Count }} minute read"
 
 - id: return
   translation: "Return"


### PR DESCRIPTION
Typically, describing a the length of time it takes to read a post would be worded as "It is a four-minute read", so in this form it should reflect that as "X minute read".

Just English quirkiness.

I love your theme and am using it at https://benboyle.ca
I think other English users of this theme may appreciate this change to the master branch.