### PR TITLE
Allow baseUrl to be a subdirectory

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,5 @@
-baseURL                   = "https://example.com"
+baseURL                    = "https://example.com"
+relativeURLS               = true
 builddrafts                = false
 languageCode               = "zn-Hans"
 canonifyurls               = true


### PR DESCRIPTION
Add the following code in the config.toml will make all URLs relative i.e. we can set the baseUrl as http://example.com/ or http://example.com/blogs/
```
relativeURLS = true
```
[ https://gohugo.io/extras/urls/#relative-urls]( https://gohugo.io/extras/urls/#relative-urls)
