### PR TITLE
根据主题增加并修改模板信息

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,18 @@
-+++
-title = "{{ replace .TranslationBaseName '-' ' ' | title }}"
-date = "{{ .Date }}"
-draft = true
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+publishdate: {{ .Date }}
+lastmod: {{ .Date }}
+draft: false
+toc: true
+img: ""
+summary: ""
+tags: []
+series: []
+categories: []
+contentCopyright: “”
+author: ""
+---
+<hr>
 
-+++
+


### PR DESCRIPTION
最新版本Hugo使用`new`创建的Markdown文件使用的模板使用的是冒号不是等号。同时，定义该区域为`---`而不是`+++`。同时为了书写时，不会出现内容错位到文章信息部分，增加了`<hr>`。本人初入前端，对主题研究不透，文档阅读不周，如有打扰，实属冒昧。祝主题日益完善。