### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/homepage-header.html
+++ b/layouts/partials/homepage-header.html
@@ -101,30 +101,30 @@
         <!-- Ref Icon -->
         <div class="mt-2" style="font-size: 2rem; color: white;">
             {{ if $.Site.Params.github }}
-              <a href="{{ $.Site.Params.github }}" target="_blank" rel="noopener"><i class="fab fa-github pr-1" aria-hidden="true"></i></a>    
+              <a href="{{ $.Site.Params.github }}" target="_blank" rel="noopener me"><i class="fab fa-github pr-1" aria-hidden="true"></i></a>    
             {{ end }}
             {{ if $.Site.Params.linkedin }}
-              <a href="{{ $.Site.Params.linkedin }}" target="_blank" rel="noopener"><i class="fab fa-linkedin pr-1" aria-hidden="true"></i></a>
+              <a href="{{ $.Site.Params.linkedin }}" target="_blank" rel="noopener me"><i class="fab fa-linkedin pr-1" aria-hidden="true"></i></a>
             {{ end }}
 
             {{ if $.Site.Params.facebook }}
-              <a href="{{ $.Site.Params.facebook }}" target="_blank" rel="noopener"><i class="fab fa-facebook pr-1" aria-hidden="true"></i></a>
+              <a href="{{ $.Site.Params.facebook }}" target="_blank" rel="noopener me"><i class="fab fa-facebook pr-1" aria-hidden="true"></i></a>
             {{ end }}
 
             {{ if $.Site.Params.googleplus }}
-            <a href="{{ $.Site.Params.googleplus }}" target="_blank" rel="noopener"><i class="fab fa-google-plus pr-1" aria-hidden="true"></i></a>
+            <a href="{{ $.Site.Params.googleplus }}" target="_blank" rel="noopener me"><i class="fab fa-google-plus pr-1" aria-hidden="true"></i></a>
             {{ end }}
 
             {{ if $.Site.Params.twitter }}
-                <a href="{{ $.Site.Params.twitter }}" target="_blank" rel="noopener"><i class="fab fa-twitter pr-1" aria-hidden="true"></i></a>
+                <a href="{{ $.Site.Params.twitter }}" target="_blank" rel="noopener me"><i class="fab fa-twitter pr-1" aria-hidden="true"></i></a>
             {{ end }}
 
             {{ if $.Site.Params.instagram }}
-                <a href="{{ $.Site.Params.instagram }}" target="_blank" rel="noopener"><i class="fab fa-instagram pr-1" aria-hidden="true"></i></a>
+                <a href="{{ $.Site.Params.instagram }}" target="_blank" rel="noopener me"><i class="fab fa-instagram pr-1" aria-hidden="true"></i></a>
             {{ end }}
     
             {{ if $.Site.Params.px500 }}
-                <a href="{{ $.Site.Params.px500 }}" target="_blank" rel="noopener"><i class="fab fa-500px pr-1" aria-hidden="true"></i></a>
+                <a href="{{ $.Site.Params.px500 }}" target="_blank" rel="noopener me"><i class="fab fa-500px pr-1" aria-hidden="true"></i></a>
             {{ end }}
     
         


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.